### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,6 +13,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+permissions:
+  contents: read
 runs-on: self-hosted
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/nixonzilla/mistllc/security/code-scanning/1](https://github.com/nixonzilla/mistllc/security/code-scanning/1)

The fix involves adding a `permissions` block to the workflow to explicitly define the required permissions. Since the workflow primarily reads repository contents to build the project and uploads a dependency graph, the permissions can be limited to `contents: read`. If additional functionality requiring `write` access is introduced later (e.g., creating pull requests), these permissions can be adjusted accordingly.

The `permissions` block should be added at the root level of the workflow, applying to all jobs, as there is no evidence that different jobs require differing permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
