### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,6 @@
 name: Build and Test with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nixonzilla/mistllc/security/code-scanning/5](https://github.com/nixonzilla/mistllc/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to read the repository contents (for checkout and build), the correct setting is `contents: read`. This can be added at the workflow level (top-level, after `name:` and before `on:`) to apply to all jobs, or at the job level (under `build:`) if you want to scope it to a specific job. The simplest and most maintainable approach is to add it at the top level, ensuring all jobs inherit the least privilege.

**What to change:**  
- In `.github/workflows/maven.yml`, add the following block after the `name:` line and before the `on:` block:
  ```yaml
  permissions:
    contents: read
  ```
- No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
